### PR TITLE
explicitly matching grep pattern

### DIFF
--- a/lib/nfp
+++ b/lib/nfp
@@ -108,8 +108,8 @@ function assign_user_role_credential {
     source $TOP_DIR/openrc admin admin
     #set -x
     serviceTenantID=`keystone tenant-list | grep "service" | awk '{print $2}'`
-    serviceRoleID=`keystone role-list | grep "service" | awk '{print $2}'`
-    adminRoleID=`keystone role-list | grep "admin" | awk '{print $2}'`
+    serviceRoleID=`keystone role-list | grep -w '[^.]service[^.]' | awk '{print $2}'`
+    adminRoleID=`keystone role-list | grep -w '[^.]admin[^.]' | awk '{print $2}'`
     keystone user-role-add --user nova --tenant $serviceTenantID --role $serviceRoleID
     keystone user-role-add --user neutron --tenant $serviceTenantID --role $adminRoleID
 }


### PR DESCRIPTION
Barbican is a required plugin for lbaasv2 ssl. When install barbican, it will create a role "key-manager:service-admin" which matches both "admin" and "service" pattern. We need to change the grep pattern explicitly matches the whole word "admin" and "service".
